### PR TITLE
fixing a small typo

### DIFF
--- a/03-anatomy.rst
+++ b/03-anatomy.rst
@@ -127,7 +127,7 @@ conversion method:
    b'\x04\x00'
    >>> offset_start = 0
    >>> for i in range(Z.ndim):
-   ...     offset_start + = Z.strides[i] * index[i]
+   ...     offset_start += Z.strides[i] * index[i]
    >>> offset_end = offset_start + Z.itemsize
    >>> print(Z.tobytes()[offset_start:offset_end]
    b'\x04\x00'


### PR DESCRIPTION
Fixing a very small typo in 03-anatomy.rst:130. There is a space between "+" and " ". I wish that my next pull request would be more better than this! 