### PR TITLE
Gardening: typos, formatting, updates

### DIFF
--- a/02-introduction.rst
+++ b/02-introduction.rst
@@ -29,6 +29,8 @@ it's readable, but it is slow:
 
 .. code:: python
 
+   import random
+
    class RandomWalker:
        def __init__(self):
            self.position = 0
@@ -38,7 +40,7 @@ it's readable, but it is slow:
            for i in range(n):
                yield self.position
                self.position += 2*random.randint(0, 1) - 1
-           
+
    walker = RandomWalker()
    walk = [position for position in walker.walk(1000)]
 
@@ -51,7 +53,7 @@ Benchmarking gives us:
    >>> timeit("[position for position in walker.walk(n=10000)]", globals())
    10 loops, best of 3: 15.7 msec per loop
 
-       
+
 **Procedural approach**
 
 For such a simple problem, we can probably save the class definition and
@@ -59,6 +61,8 @@ concentrate only on the walk method that computes successive positions after
 each random step.
 
 .. code:: python
+
+   import random
 
    def random_walk(n):
        position = 0
@@ -80,9 +84,9 @@ we saved probably come from the inner Python object-oriented machinery.
    >>> timeit("random_walk(n=10000)", globals())
    10 loops, best of 3: 15.6 msec per loop
 
-   
+
 **Vectorized approach**
-   
+
 But we can do better using the `itertools
 <https://docs.python.org/3.6/library/itertools.html>`_ Python module that
 offers *a set of functions creating iterators for efficient looping*. If we
@@ -92,14 +96,16 @@ loop:
 
 .. code:: python
 
+   # Only available from Python 3.6
+   from itertools import accumulate
+   import random
+
    def random_walk_faster(n=1000):
-       from itertools import accumulate
-       # Only available from Python 3.6
        steps = random.choices([-1,+1], k=n)
        return [0]+list(accumulate(steps))
 
-    walk = random_walk_faster(1000)
-   
+   walk = random_walk_faster(1000)
+
 In fact, we've just *vectorized* our function. Instead of looping for picking
 sequential steps and add them to the current position, we first generated all the
 steps at once and used the `accumulate
@@ -109,7 +115,7 @@ things faster:
 
 .. code:: pycon
 
-   >>> from tools import timeit
+   >>> from tools import timeit # Reminder: run from the `code <code>`_ folder
    >>> timeit("random_walk_faster(n=10000)", globals())
    10 loops, best of 3: 2.21 msec per loop
 
@@ -118,16 +124,16 @@ bad. But the advantage of this new version is that it makes NumPy vectorization
 super simple. We just have to translate itertools call into NumPy ones.
 
 .. code:: python
-       
+
    def random_walk_fastest(n=1000):
        # No 's' in NumPy choice (Python offers choice & choices)
        steps = np.random.choice([-1,+1], n)
        return np.cumsum(steps)
 
    walk = random_walk_fastest(1000)
-           
+
 Not too difficult, but we gained a factor 500x using NumPy:
- 
+
 .. code:: pycon
 
    >>> from tools import timeit
@@ -154,7 +160,7 @@ second (or your name is `Jaime Fernández del Río
 and you don't need to read this book).
 
 .. code:: python
-          
+
    def function_1(seq, sub):
        return [i for i in range(len(seq) - len(sub) +1) if seq[i:i+len(sub)] == sub]
 

--- a/03-anatomy.rst
+++ b/03-anatomy.rst
@@ -3,11 +3,11 @@ Anatomy of an array
 
 .. contents:: **Contents**
    :local:
-        
+
 
 Introduction
 ------------
-      
+
 As explained in the Preface_, you should have a basic experience with NumPy to
 read this book. If this is not the case, you'd better start with a beginner
 tutorial before coming back here. Consequently I'll only give here a quick
@@ -48,7 +48,7 @@ be divided by the new dtype itemsize.
    100 loops, best of 3: 841 usec per loop
    >>> timeit("Z.view(np.int8)[...] = 0", globals())
    100 loops, best of 3: 630 usec per loop
-                
+
 Interestingly enough, the obvious way of clearing all the values is not the
 fastest. By casting the array into a larger data type such as `np.float64`, we
 gained a 25% speed factor. But, by viewing the array as a byte array
@@ -87,11 +87,11 @@ the number of dimensions is 2 (`len(Z.shape)`).
 
 .. code:: pycon
 
-   >>> print(Z.itemsize)
+   >>> Z.itemsize
    2
-   >>> print(Z.shape)
+   >>> Z.shape
    (3, 3)
-   >>> print(Z.ndim)
+   >>> Z.ndim
    2
 
 Furthermore and because Z is not a view, we can deduce the
@@ -100,11 +100,11 @@ Furthermore and because Z is not a view, we can deduce the
 .. code:: pycon
 
    >>> strides = Z.shape[1]*Z.itemsize, Z.itemsize
-   >>> print(strides)
+   >>> strides
    (6, 2)
-   >>> print(Z.strides)
+   >>> Z.strides
    (6, 2)
-  
+
 With all these information, we know how to access a specific item (designed by
 an index tuple) and more precisely, how to compute the start and end offsets:
 
@@ -113,7 +113,9 @@ an index tuple) and more precisely, how to compute the start and end offsets:
    offset_start = 0
    for i in range(Z.ndim):
        offset_start += Z.strides[i] * index[i]
+
    offset_end = offset_start + Z.itemsize
+   offset_end
 
 Let's see if this is correct using the `tobytes
 <https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.tobytes.html>`_
@@ -123,40 +125,41 @@ conversion method:
 
    >>> Z = np.arange(9).reshape(3, 3).astype(np.int16)
    >>> index = 1, 1
-   >>> print(Z[index].tobytes())
+   >>> Z[index].tobytes()
    b'\x04\x00'
    >>> offset_start = 0
    >>> for i in range(Z.ndim):
    ...     offset_start += Z.strides[i] * index[i]
+   ...
    >>> offset_end = offset_start + Z.itemsize
-   >>> print(Z.tobytes()[offset_start:offset_end])
+   >>> Z.tobytes()[offset_start:offset_end]
    b'\x04\x00'
 
 
 This array can be actually considered from different perspectives (i.e. layouts):
-   
+
 **Item layout**
-   
+
 .. code::
    :class: output
 
-                  shape[1]
+                 Z.shape[1]
                     (=3)
-               ┌───────────┐   
+               ┌───────────┐
 
-            ┌  ┌───┬───┬───┐  ┐ 
+            ┌  ┌───┬───┬───┐  ┐
             │  │ 0 │ 1 │ 2 │  │
-            │  ├───┼───┼───┤  │     
-   shape[0] │  │ 3 │ 4 │ 5 │  │ len(Z)
+            │  ├───┼───┼───┤  │
+ Z.shape[0] │  │ 3 │ 4 │ 5 │  │ len(Z)
     (=3)    │  ├───┼───┼───┤  │  (=3)
             │  │ 6 │ 7 │ 8 │  │
             └  └───┴───┴───┘  ┘
 
 **Flattened item layout**
-   
+
 .. code::
    :class: output
-  
+
    ┌───┬───┬───┬───┬───┬───┬───┬───┬───┐
    │ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │
    └───┴───┴───┴───┴───┴───┴───┴───┴───┘
@@ -164,25 +167,25 @@ This array can be actually considered from different perspectives (i.e. layouts)
    └───────────────────────────────────┘
                   Z.size
                    (=9)
-   
+
 
 **Memory layout (C order, big endian)**
-   
+
 .. code::
    :class: output
 
-                            strides[1]
+                          Z.strides[1]
                               (=2)
                      ┌─────────────────────┐
 
              ┌       ┌──────────┬──────────┐ ┐
              │ p+00: │ 00000000 │ 00000000 │ │
              │       ├──────────┼──────────┤ │
-             │ p+02: │ 00000000 │ 00000001 │ │ strides[0]
-             │       ├──────────┼──────────┤ │   (=2x3)
+             │ p+02: │ 00000000 │ 00000001 │ │ Z.strides[0]
+             │       ├──────────┼──────────┤ │    (=2x3)
              │ p+04  │ 00000000 │ 00000010 │ │
              │       ├──────────┼──────────┤ ┘
-             │ p+06  │ 00000000 │ 00000011 │ 
+             │ p+06  │ 00000000 │ 00000011 │
              │       ├──────────┼──────────┤
    Z.nbytes  │ p+08: │ 00000000 │ 00000100 │
    (=3x3x2)  │       ├──────────┼──────────┤
@@ -195,14 +198,14 @@ This array can be actually considered from different perspectives (i.e. layouts)
              │ p+16: │ 00000000 │ 00001000 │
              └       └──────────┴──────────┘
 
-                     └─────────────────────┘   
+                     └─────────────────────┘
                            Z.itemsize
                         Z.dtype.itemsize
-                              (=2) 
+                              (=2)
 
 
 If we now take a slice of `Z`, the result is a view of the base array `Z`:
-                        
+
 .. code-block:: python
 
    V = Z[::2,::2]
@@ -211,70 +214,70 @@ Such view is specified using a shape, a dtype **and** strides because strides
 cannot be deduced anymore from the dtype and shape only:
 
 **Item layout**
-   
+
 .. code::
    :class: output
 
-                  shape[1]
+                 V.shape[1]
                     (=2)
-               ┌───────────┐   
+               ┌───────────┐
 
-            ┌  ┌───┬╌╌╌┬───┐  ┐           
+            ┌  ┌───┬╌╌╌┬───┐  ┐
             │  │ 0 │   │ 2 │  │            ┌───┬───┐
             │  ├───┼╌╌╌┼───┤  │            │ 0 │ 2 │
-   shape[0] │  ╎   ╎   ╎   ╎  │ len(Z)  →  ├───┼───┤
+ V.shape[0] │  ╎   ╎   ╎   ╎  │ len(V)  →  ├───┼───┤
     (=2)    │  ├───┼╌╌╌┼───┤  │  (=2)      │ 6 │ 8 │
             │  │ 6 │   │ 8 │  │            └───┴───┘
-            └  └───┴╌╌╌┴───┘  ┘           
-                                          
+            └  └───┴╌╌╌┴───┘  ┘
+
 **Flattened item layout**
-   
+
 .. code::
    :class: output
-  
+
    ┌───┬╌╌╌┬───┬╌╌╌┬╌╌╌┬╌╌╌┬───┬╌╌╌┬───┐       ┌───┬───┬───┬───┐
    │ 0 │   │ 2 │   ╎   ╎   │ 6 │   │ 8 │   →   │ 0 │ 2 │ 6 │ 8 │
    └───┴╌╌╌┴───┴╌╌╌┴╌╌╌┴╌╌╌┴───┴╌╌╌┴───┘       └───┴───┴───┴───┘
    └─┬─┘   └─┬─┘           └─┬─┘   └─┬─┘
-     └───┬───┘               └───┬───┘  
+     └───┬───┘               └───┬───┘
          └───────────┬───────────┘
-                  Z.size
+                  V.size
                    (=4)
 
-   
+
 
 **Memory layout (C order, big endian)**
-   
+
 .. code::
    :class: output
-   
-                 ┌        ┌──────────┬──────────┐ ┐             ┐
-               ┌─┤  p+00: │ 00000000 │ 00000000 │ │             │
-               │ └        ├──────────┼──────────┤ │ strides[1]  │
-             ┌─┤    p+02: │          │          │ │   (=4)      │ 
-             │ │ ┌        ├──────────┼──────────┤ ┘             │ 
-             │ └─┤  p+04  │ 00000000 │ 00000010 │               │
-             │   └        ├──────────┼──────────┤               │ strides[0] 
-             │      p+06: │          │          │               │   (=12)
-             │            ├──────────┼──────────┤               │
-   Z.nbytes ─┤      p+08: │          │          │               │
-     (=8)    │            ├──────────┼──────────┤               │
-             │      p+10: │          │          │               │
-             │   ┌        ├──────────┼──────────┤               ┘              
+
+                 ┌        ┌──────────┬──────────┐ ┐              ┐
+               ┌─┤  p+00: │ 00000000 │ 00000000 │ │              │
+               │ └        ├──────────┼──────────┤ │ V.strides[1] │
+             ┌─┤    p+02: │          │          │ │    (=4)      │
+             │ │ ┌        ├──────────┼──────────┤ ┘              │
+             │ └─┤  p+04  │ 00000000 │ 00000010 │                │
+             │   └        ├──────────┼──────────┤                │ V.strides[0]
+             │      p+06: │          │          │                │    (=12)
+             │            ├──────────┼──────────┤                │
+   V.nbytes ─┤      p+08: │          │          │                │
+     (=8)    │            ├──────────┼──────────┤                │
+             │      p+10: │          │          │                │
+             │   ┌        ├──────────┼──────────┤                ┘
              │ ┌─┤  p+12: │ 00000000 │ 00000110 │
              │ │ └        ├──────────┼──────────┤
              └─┤    p+14: │          │          │
                │ ┌        ├──────────┼──────────┤
                └─┤  p+16: │ 00000000 │ 00001000 │
                  └        └──────────┴──────────┘
-                               
+
                           └─────────────────────┘
-                                Z.itemsize
-                             Z.dtype.itemsize
-                                   (=2)                                        
+                                V.itemsize
+                             V.dtype.itemsize
+                                   (=2)
 
 
-                        
+
 Views and copies
 ----------------
 
@@ -296,13 +299,13 @@ modifies the base array while this is not true in the second case:
    >>> Z = np.zeros(9)
    >>> Z_view = Z[:3]
    >>> Z_view[...] = 1
-   >>> print(Z)
-   [ 1.  1.  1.  0.  0.  0.  0.  0.  0.]
+   >>> Z
+   array([1., 1., 1., 0., 0., 0., 0., 0., 0.])
    >>> Z = np.zeros(9)
-   >>> Z_copy = Z[[0,1,2]]
+   >>> Z_copy = Z[[0, 1, 2]]
    >>> Z_copy[...] = 1
-   >>> print(Z)
-   [ 0.  0.  0.  0.  0.  0.  0.  0.  0.]
+   >>> Z
+   array([0., 0., 0., 0., 0., 0., 0., 0., 0.])
 
 Thus, if you need fancy indexing, it's better to keep a copy of your fancy index
 (especially if it was complex to compute it) and to work with it:
@@ -310,28 +313,28 @@ Thus, if you need fancy indexing, it's better to keep a copy of your fancy index
 .. code:: pycon
 
    >>> Z = np.zeros(9)
-   >>> index = [0,1,2]
+   >>> index = [0, 1, 2]
    >>> Z[index] = 1
-   >>> print(Z)
-   [ 1.  1.  1.  0.  0.  0.  0.  0.  0.]
+   >>> Z
+   array([1., 1., 1., 0., 0., 0., 0., 0., 0.])
 
 If you are unsure if the result of your indexing is a view or a copy, you can
 check what is the `base` of your result. If it is `None`, then you result is a
 copy:
 
-   
+
 .. code:: pycon
 
-   >>> Z = np.random.uniform(0,1,(5,5))
-   >>> Z1 = Z[:3,:]
-   >>> Z2 = Z[[0,1,2], :]
-   >>> print(np.allclose(Z1,Z2))
+   >>> Z = np.random.uniform(0, 1, (5, 5))
+   >>> Z1 = Z[:3, :]
+   >>> Z2 = Z[[0, 1, 2], :]
+   >>> np.allclose(Z1, Z2)
    True
-   >>> print(Z1.base is Z)
+   >>> Z1.base is Z
    True
-   >>> print(Z2.base is Z)
+   >>> Z2.base is Z
    False
-   >>> print(Z2.base is None)
+   >>> Z2.base is None
    True
 
 Note that some NumPy functions return a view when possible (e.g. `ravel
@@ -341,15 +344,15 @@ while some others always return a copy (e.g. `flatten
 
 .. code:: pycon
 
-    >>> Z = np.zeros((5,5))
+    >>> Z = np.zeros((5, 5))
     >>> Z.ravel().base is Z
     True
-    >>> Z[::2,::2].ravel().base is Z
+    >>> Z[::2, ::2].ravel().base is Z
     False
     >>> Z.flatten().base is Z
     False
 
-   
+
 Temporary copy
 ++++++++++++++
 
@@ -359,8 +362,8 @@ when you are doing some arithmetic with arrays:
 
 .. code:: pycon
 
-   >>> X = np.ones(10, dtype=np.int)
-   >>> Y = np.ones(10, dtype=np.int)
+   >>> X = np.ones(10, dtype=int)
+   >>> Y = np.ones(10, dtype=int)
    >>> A = 2*X + 2*Y
 
 In the example above, three intermediate arrays have been created. One for
@@ -373,30 +376,28 @@ you don't need `X` nor `Y` afterwards, an alternate solution would be:
 
 .. code:: pycon
 
-   >>> X = np.ones(10, dtype=np.int)
-   >>> Y = np.ones(10, dtype=np.int)
+   >>> X = np.ones(10, dtype=int)
+   >>> Y = np.ones(10, dtype=int)
    >>> np.multiply(X, 2, out=X)
    >>> np.multiply(Y, 2, out=Y)
    >>> np.add(X, Y, out=X)
 
-Using this alternate solution, no temporary array has been created. The problem 
-is that there are many other cases where such copies need to be created and 
+Using this alternate solution, no temporary array has been created. The problem
+is that there are many other cases where such copies need to be created and
 this impacts the performance like demonstrated in the example below:
 
 .. code:: pycon
 
-   >>> X = np.ones(1000000000, dtype=np.int)
-   >>> Y = np.ones(1000000000, dtype=np.int)
-   >>> timeit("X = X + 2.0*Y", globals())
+   >>> X = np.ones(100000000, dtype=int)
+   >>> Y = np.ones(100000000, dtype=int)
+   >>> timeit("global X; X = X + 2.0*Y", globals())
    100 loops, best of 3: 3.61 ms per loop
-   >>> timeit("X = X + 2*Y", globals())
+   >>> timeit("global X; X = X + 2*Y", globals())
    100 loops, best of 3: 3.47 ms per loop
-   >>> timeit("X += 2*Y", globals())
+   >>> timeit("global X; X += 2*Y", globals())
    100 loops, best of 3: 2.79 ms per loop
    >>> timeit("np.add(X, Y, out=X); np.add(X, Y, out=X)", globals())
    1000 loops, best of 3: 1.57 ms per loop
-          
-
 
 Conclusion
 ----------
@@ -423,7 +424,7 @@ First, we need to check if `Z1` is the base of `Z2`
 
 .. code-block::
 
-   >>> print(Z2.base is Z1)
+   >>> Z2.base is Z1
    True
 
 At this point, we know `Z2` is a view of `Z1`, meaning `Z2` can be expressed as
@@ -436,7 +437,7 @@ directly compare the first stride only:
 .. code-block::
 
    >>> step = Z2.strides[0] // Z1.strides[0]
-   >>> print(step)
+   >>> step
    2
 
 Next difficulty is to find the `start` and the `stop` indices. To do this, we
@@ -447,13 +448,13 @@ end-points of an array.
    :class: output
 
      byte_bounds(Z1)[0]                  byte_bounds(Z1)[-1]
-         ↓                                       ↓ 
+         ↓                                       ↓
       ╌╌╌┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬╌╌
    Z1    │ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │
       ╌╌╌┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴╌╌
 
          byte_bounds(Z2)[0]      byte_bounds(Z2)[-1]
-             ↓                           ↓ 
+             ↓                           ↓
       ╌╌╌╌╌╌╌┬───┬╌╌╌┬───┬╌╌╌┬───┬╌╌╌┬───┬╌╌╌╌╌╌╌╌╌╌
    Z2        │ 1 │   │ 3 │   │ 5 │   │ 7 │
       ╌╌╌╌╌╌╌┴───┴╌╌╌┴───┴╌╌╌┴───┴╌╌╌┴───┴╌╌╌╌╌╌╌╌╌╌
@@ -462,11 +463,11 @@ end-points of an array.
 .. code-block::
 
    >>> offset_start = np.byte_bounds(Z2)[0] - np.byte_bounds(Z1)[0]
-   >>> print(offset_start) # bytes
-   8 
+   >>> offset_start # bytes
+   8
 
    >>> offset_stop = np.byte_bounds(Z2)[-1] - np.byte_bounds(Z1)[-1]
-   >>> print(offset_stop) # bytes
+   >>> offset_stop # bytes
    -16
 
 Converting these offsets into indices is straightforward using the `itemsize`
@@ -478,14 +479,14 @@ items size of Z1 to get the right end index.
 
    >>> start = offset_start // Z1.itemsize
    >>> stop = Z1.size + offset_stop // Z1.itemsize
-   >>> print(start, stop, step)
-   1, 8, 2
+   >>> start, stop, step
+   (1, 8, 2)
 
 Last we test our results:
 
 .. code-block::
 
-   >>> print(np.allclose(Z1[start:stop:step], Z2))
+   >>> np.allclose(Z1[start:stop:step], Z2)
    True
 
 As an exercise, you can improve this first and very simple implementation by
@@ -495,6 +496,3 @@ taking into account:
 * Multi-dimensional arrays
 
 `Solution <code/find_index.py>`_ to the exercise.
-
-
-                        


### PR DESCRIPTION
I worked through the first half and made some minor updates & fixes - HTH. Feel free to use however you like; happy to make edits/separate commits if needed. Thanks for providing this book!

* removed trailing spaces
* fixed some indentation errors
* minor text clarifications
* unnecessary `print` (AFAIK!)
* fixed typos (`V` vs `Z`) & ambiguity in the Memory layout
* update to new numpy array format output
* added `global`s to make `timeit` work (not sure a better way)
* half-heartedly added spaces after commas