### PR TITLE
Use xor on bool in mandelbrot_numpy_2, fix #110

### DIFF
--- a/code/mandelbrot_numpy_2.py
+++ b/code/mandelbrot_numpy_2.py
@@ -33,7 +33,7 @@ def mandelbrot(xmin, xmax, ymin, ymax, xn, yn, itermax, horizon=2.0):
         Z_[Xi[I], Yi[I]] = Z[I]
 
         # Keep going with those who have not diverged yet
-        np.negative(I, I)
+        I = ~I
         Z = Z[I]
         Xi, Yi = Xi[I], Yi[I]
         C = C[I]


### PR DESCRIPTION
Hi @rougier and thanks for this helpful book. 

This is just a quick PR to make the same fix that @ev-br made in #111, but this one fixes Dan Goodman's implementation of the mandelbrot set, as @ev-br mentioned here: https://github.com/rougier/from-python-to-numpy/issues/110#issuecomment-1514306165