### PR TITLE
Update 04-code-vectorization.rst

### DIFF
--- a/04-code-vectorization.rst
+++ b/04-code-vectorization.rst
@@ -532,7 +532,7 @@ a 10x factor speed improvement compared to the Python version.
            Z_[Xi[I], Yi[I]] = Z[I]
 
            # Keep going with those who have not diverged yet
-           np.negative(I,I)
+           I = ~I
            Z = Z[I]
            Xi, Yi = Xi[I], Yi[I]
            C = C[I]


### PR DESCRIPTION
updated versions of numpy return the following error for the previous version:

TypeError: The numpy boolean negative, the `-` operator, is not supported, use the `~` operator or the logical_not function instead.