### PR TITLE
Update outdated urls

### DIFF
--- a/02-introduction.rst
+++ b/02-introduction.rst
@@ -88,7 +88,7 @@ we saved probably come from the inner Python object-oriented machinery.
 **Vectorized approach**
 
 But we can do better using the `itertools
-<https://docs.python.org/3.6/library/itertools.html>`_ Python module that
+<https://docs.python.org/3.13/library/itertools.html>`_ Python module that
 offers *a set of functions creating iterators for efficient looping*. If we
 observe that a random walk is an accumulation of steps, we can rewrite the
 function by first generating all the steps and accumulate them without any
@@ -96,7 +96,6 @@ loop:
 
 .. code:: python
 
-   # Only available from Python 3.6
    from itertools import accumulate
    import random
 
@@ -109,7 +108,7 @@ loop:
 In fact, we've just *vectorized* our function. Instead of looping for picking
 sequential steps and add them to the current position, we first generated all the
 steps at once and used the `accumulate
-<https://docs.python.org/3.6/library/itertools.html#itertools.accumulate>`_
+<https://docs.python.org/3.13/library/itertools.html#itertools.accumulate>`_
 function to compute all the positions. We got rid of the loop and this makes
 things faster:
 

--- a/03-anatomy.rst
+++ b/03-anatomy.rst
@@ -62,7 +62,7 @@ Memory layout
 -------------
 
 The `NumPy documentation
-<https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html>`_ defines the
+<https://numpy.org/doc/stable/reference/arrays.ndarray.html>`_ defines the
 ndarray class very clearly:
 
   *An instance of class ndarray consists of a contiguous one-dimensional segment
@@ -73,9 +73,9 @@ ndarray class very clearly:
 Said differently, an array is mostly a contiguous block of memory whose parts
 can be accessed using an indexing scheme. Such indexing scheme is in turn
 defined by a `shape
-<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.shape.html#numpy.ndarray.shape>`_
+<https://numpy.org/doc/stable/reference/generated/numpy.ndarray.shape.html#numpy.ndarray.shape>`_
 and a `data type
-<https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html>`_ and this is
+<https://numpy.org/doc/stable/reference/arrays.dtypes.html>`_ and this is
 precisely what is needed when you define a new array:
 
 .. code:: python
@@ -95,7 +95,7 @@ the number of dimensions is 2 (`len(Z.shape)`).
    2
 
 Furthermore and because Z is not a view, we can deduce the
-`strides <https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.strides.html#numpy.ndarray.strides>`_ of the array that define the number of bytes to step in each dimension when traversing the array.
+`strides <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.strides.html#numpy.ndarray.strides>`_ of the array that define the number of bytes to step in each dimension when traversing the array.
 
 .. code:: pycon
 
@@ -118,7 +118,7 @@ an index tuple) and more precisely, how to compute the start and end offsets:
    offset_end
 
 Let's see if this is correct using the `tobytes
-<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.tobytes.html>`_
+<https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tobytes.html>`_
 conversion method:
 
 .. code:: python
@@ -338,9 +338,9 @@ copy:
    True
 
 Note that some NumPy functions return a view when possible (e.g. `ravel
-<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ravel.html>`_)
+<https://numpy.org/doc/stable/reference/generated/numpy.ravel.html>`_)
 while some others always return a copy (e.g. `flatten
-<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.flatten.html#numpy.ndarray.flatten>`_):
+<https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flatten.html#numpy.ndarray.flatten>`_):
 
 .. code:: pycon
 

--- a/03-anatomy.rst
+++ b/03-anatomy.rst
@@ -289,8 +289,8 @@ Direct and indirect access
 ++++++++++++++++++++++++++
 
 First, we have to distinguish between `indexing
-<https://docs.scipy.org/doc/numpy/user/basics.indexing.html#>`_ and `fancy
-indexing <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#advanced-indexing>`_. The first will always return a view while the second will return a
+<https://numpy.org/doc/stable/user/basics.indexing.html#basic-indexing>`_ and `fancy
+indexing <https://numpy.org/doc/stable/user/basics.indexing.html#advanced-indexing>`_. The first will always return a view while the second will return a
 copy. This difference is important because in the first case, modifying the view
 modifies the base array while this is not true in the second case:
 

--- a/04-code-vectorization.rst
+++ b/04-code-vectorization.rst
@@ -575,7 +575,7 @@ Exercise
 
 .. note::
 
-   You should look at the `ufunc.reduceat <https://docs.scipy.org/doc/numpy/reference/generated/numpy.ufunc.reduceat.html>`_ method that performs a (local) reduce with specified slices over a single axis.
+   You should look at the `ufunc.reduceat <https://numpy.org/doc/stable/reference/generated/numpy.ufunc.reduceat.html>`_ method that performs a (local) reduce with specified slices over a single axis.
 
 We now want to measure the fractal dimension of the Mandelbrot set using the
 `Minkowski–Bouligand dimension
@@ -769,7 +769,7 @@ We could have used the scipy `cdist
 <https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html>`_
 but we'll need the `dx` and `dy` arrays later. Once those have been computed,
 it is faster to use the `hypot
-<https://docs.scipy.org/doc/numpy/reference/generated/numpy.hypot.html>`_
+<https://numpy.org/doc/stable/reference/generated/numpy.hypot.html>`_
 method. Note that distance shape is `(n, n)` and each line relates to one boid,
 i.e. each line gives the distance to all other boids (including self).
 

--- a/06-custom-vectorization.rst
+++ b/06-custom-vectorization.rst
@@ -12,7 +12,7 @@ Introduction
 
 One of the strengths of NumPy is that it can be used to build new objects or to
 `subclass the ndarray
-<https://docs.scipy.org/doc/numpy/user/basics.subclassing.html>`_ object. This
+<https://numpy.org/doc/stable/user/basics.subclassing.html>`_ object. This
 later process is a bit tedious but it is worth the effort because it allows you
 to improve the `ndarray` object to suit your problem. We'll examine in
 the following section two real-world cases (typed list and memory-aware array)
@@ -332,7 +332,7 @@ Array subclass
 ++++++++++++++
 
 As explained in the `Subclassing ndarray
-<https://docs.scipy.org/doc/numpy/user/basics.subclassing.html>`_
+<https://numpy.org/doc/stable/user/basics.subclassing.html>`_
 documentation, subclassing `ndarray` is complicated by the fact that new
 instances of `ndarray` classes can come about in three different ways:
 

--- a/10-bibliography.rst
+++ b/10-bibliography.rst
@@ -29,7 +29,7 @@ Tutorials
 .. _tutorial-5: http://cs231n.github.io/python-numpy-tutorial/
 
 .. |tutorial-6| replace:: Quickstart tutorial
-.. _tutorial-6: https://docs.scipy.org/doc/numpy/user/quickstart.html
+.. _tutorial-6: https://numpy.org/doc/stable/user/quickstart.html
 
 .. |tutorial-7| replace:: Numpy medkits
 .. _tutorial-7: http://mentat.za.net/numpy/numpy_advanced_slides/

--- a/code/random_walk.py
+++ b/code/random_walk.py
@@ -32,7 +32,6 @@ def random_walk(n):
 
 def random_walk_faster(n=1000):
     from itertools import accumulate
-    # Only available from Python 3.6
     steps = random.choices([-1,+1], k=n)
     return [0]+list(accumulate(steps))
 


### PR DESCRIPTION
The 1st commit fixes invalid links.

The others are more or less useless.

close https://github.com/rougier/from-python-to-numpy/issues/78, the link is updated.